### PR TITLE
Tweaks

### DIFF
--- a/lib/src/feature_overlay.dart
+++ b/lib/src/feature_overlay.dart
@@ -239,7 +239,10 @@ class _FeatureOverlayState extends State<FeatureOverlay>
           _setOverlayState(FeatureOverlayState.closed);
           break;
         case FeatureOverlayState.closed:
-          assert(to == null || to == FeatureOverlayState.closed);
+          //assert(to == null || to == FeatureOverlayState.closed);
+          if(to != null && to != FeatureOverlayState.closed) {
+              print("_DescribedFeatureOverlayState: is this a bug: transition from closed -> $to for feature: \"${widget.featureId}\" active feature:\"$_activeFeature\"");
+          }
           if (_activeFeature == widget.featureId) {
             _setOverlayState(FeatureOverlayState.onOpening);
             WidgetsBinding.instance!.addPostFrameCallback((_) async {

--- a/lib/src/feature_overlay_config.dart
+++ b/lib/src/feature_overlay_config.dart
@@ -69,6 +69,10 @@ class FeatureOverlayConfig extends InheritedWidget {
     return result!;
   }
 
+  static FeatureOverlayConfig? whenPresentOf(BuildContext context) {
+    return context.dependOnInheritedWidgetOfExactType<FeatureOverlayConfig>();
+  }
+
   @override
   void debugFillProperties(DiagnosticPropertiesBuilder properties) {
     super.debugFillProperties(properties);

--- a/lib/src/feature_overlay_target.dart
+++ b/lib/src/feature_overlay_target.dart
@@ -23,12 +23,12 @@ class FeatureOverlayTarget extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final config = FeatureOverlayConfig.of(context);
+    final config = FeatureOverlayConfig.whenPresentOf(context);
     final wrapperKey = ValueKey("wrap"); // does this improve perf?
-    if (featureIds.contains(config.activeFeatureId)) {
+    if (featureIds.contains(config?.activeFeatureId ?? null)) {
       return CompositedTransformTarget(
         key: wrapperKey,
-        link: config.layerLink,
+        link: config!.layerLink,
         child: child,
       );
     } else {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: feature_discovery_widget
 description: Feature Discovery Widget
-version: 0.0.7
+version: 0.0.8
 homepage: https://github.com/jeduden/feature_discovery_widget
 
 environment:


### PR DESCRIPTION
Dont error out if there is no configs for overlay target
Only warn if opening feature when not null and not closed.